### PR TITLE
Clean up pages and forms

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -120,3 +120,10 @@
     color: rgba(0,24,87,0.9);
     text-decoration: underline;
 }
+
+.page-title{
+    font-weight: 600;
+    font-size: 1.8em;
+    margin-bottom: 20px;
+    color: rgb(17, 37, 88);
+}

--- a/app/assets/stylesheets/visualizations.scss
+++ b/app/assets/stylesheets/visualizations.scss
@@ -1,3 +1,11 @@
 // Place all the styles related to the visualizations controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+.viz-form-section {
+    margin-bottom: 50px;
+}
+
+.viz-form-group{
+    margin-bottom: 12px;
+}

--- a/app/helpers/visualizations_helper.rb
+++ b/app/helpers/visualizations_helper.rb
@@ -1,2 +1,37 @@
 module VisualizationsHelper
+    def get_form_variable_names
+        Student.column_names.reject {|c| ["id", "student_id", "updated_at", "created_at"].include? c}
+    end
+
+
+    def get_form_chart_types
+        # Each element has format [<Display Name>, <Value>]
+        [
+            ["Bar", "bar_chart"],
+            ["Pie", "pie_chart"],
+            ["Line", "line_chart"]
+        ]
+    end
+
+
+    def get_form_variable_roles
+        # Each element has format [<Display Name>, <Value>]
+        [
+            ["Group By", "group"]
+        ]
+    end
+
+
+    def get_form_filter_types
+        [
+            ["From..To", "from_to"],
+            ["Equals", "equals"],
+            ["Is Greater Than", "greater_than"],
+            ["Is Greater Than Or Equal To", "greater_than_or_equal"],
+            ["Is Less Than", "less_than"],
+            ["Is Less Than Or Equal To", "less_than_or_equal"]
+
+        ]
+    end
+
 end

--- a/app/views/upload/index.html.erb
+++ b/app/views/upload/index.html.erb
@@ -1,10 +1,11 @@
-<h1>Upload#index</h1>
-<p>Find me in app/views/upload/index.html.erb</p>
-<h1>Upload CSV File</h1>
+<h1 class="page-title">Upload</h1>
+<p>1. Kindly select a .csv file from your system to upload and visualize graduate outcome data.</p>
+<p>2. After you have uploaded the file, click import to load the file into the system.</p>
+
 <div>
   <%= form_with url: upload_import_path, multipart: true do %>
     <%= file_field_tag :file %>
     <br>
-    <%= submit_tag "Import CSV" %>
+    <%= submit_tag "Import" %>
   <% end %>
 </div>

--- a/app/views/visualizations/index.html.erb
+++ b/app/views/visualizations/index.html.erb
@@ -1,2 +1,2 @@
-<h1>Visualizations#index</h1>
-<p>Find me in app/views/visualizations/index.html.erb</p>
+<h1 class="page-title">Preview</h1>
+<p>See all your visualizations here! Coming soon...</p>

--- a/app/views/visualizations/new.html.erb
+++ b/app/views/visualizations/new.html.erb
@@ -1,80 +1,86 @@
-<h1>Visualizations#new</h1>
-<p>Find me in app/views/visualizations/new.html.erb</p>
-
-<h1>Create New Visualization</h1>
+<h1 class="page-title">Visualize</h1>
 
 <div class="row">
-   <div class="col-md-6 col-md-offset-3">
+   <div class="col-md-20 col-md-offset-1">
      <%= form_with(model: @visualization, local: true) do |f| %>
-       <label for="chart_type">Chart Type</label><br>
+
+     <div class="viz-form-section">
+        <h4>Step 1 - Filter Data</h4>
+        <ul>
+          <%= f.fields_for :filters do |filters_form| %>
+          <li>
+            <div class="viz-form-group">
+              <label for="variable_name">Variable</label>
+              <%= filters_form.select :variable_name, options_for_select(get_form_variable_names) %>
+            </div>
+
+            <div class="viz-form-group">
+              <label for="filter_type">Filter Type</label>
+              <%= filters_form.select :filter_type, options_for_select(get_form_filter_types) %>
+            </div>
+
+            <div class="viz-form-group">
+              <label for="value1">Value1</label>
+              <%= filters_form.text_field :value1 %>
+            </div>
+            
+            <div class="viz-form-group">
+              <label for="value2">Value2</label>
+              <%= filters_form.text_field :value2 %>
+            </div>
+
+          </li>
+          <% end %>
+        </ul>
+       </div>
+
+       <div class="viz-form-section">
+          <h4>Step 2 - Select Chart Type</h4>
+          <label for="chart_type">Chart Type</label> 
+          <%= f.select :chart_type, options_for_select(get_form_chart_types) %>
+       </div>
        
-       <%= f.radio_button :chart_type, 'bar' %>
-       <label for="chart_type_bar">Bar</label><br>
        
-       <%= f.radio_button :chart_type, 'pie' %>
-       <label for="chart_type_pie">Pie</label><br>
-       
-       <%= f.radio_button :chart_type, 'line' %>
-       <label for="chart_type_line">Line</label><br>
-       
-       <label for="x_axis_title">X Axis Title</label><br>
-       <%= f.text_field :x_axis_title %>
-       
-       <label for="y_axis_title">Y Axis Title</label><br>
-       <%= f.text_field :y_axis_title %>
-       
-       <label for="chart_title">Chart Title</label><br>
-       <%= f.text_field :chart_title %>
-       <br>
-       <b>Variables:</b>
-       <ul>
-         <%= f.fields_for :variables do |variables_form| %>
-         <li>
-           <label for="name">Name</label><br>
-           
-           <%= variables_form.radio_button :name, 'class_year' %>
-           <label for="name_class_year">Year</label><br>
-           
-           <%= variables_form.radio_button :name, 'major1' %>
-           <label for="name_major1">Major 1</label><br>
-           
-           <%= variables_form.radio_button :name, 'major2' %>
-           <label for="name_major2">Major 2</label><br>
-           
-           <%= variables_form.radio_button :name, 'gender' %>
-           <label for="name_gender">Gender</label><br>
-           
-           <%= variables_form.radio_button :name, 'fed_group' %>
-           <label for="name_fed_group">Fed Grp</label><br>
-           
-           <%= variables_form.radio_button :name, 'intern' %>
-           <label for="name_intern">Intern</label><br>
-           
-           <%= variables_form.radio_button :name, 'research' %>
-           <label for="name_research">Research</label><br>
-           
-           <%= variables_form.radio_button :name, 'service' %>
-           <label for="name_service">Service</label><br>
-           
-           <%= variables_form.radio_button :name, 'career_related' %>
-           <label for="name_career_related">Related</label><br>
-           
-           <%= variables_form.radio_button :name, 'job_field' %>
-           <label for="name_job_field">Job Field</label><br>
-           
-           <label for="role">Role</label><br>
-           
-           <%= variables_form.radio_button :role, 'independent' %>
-           <label for="role_independent">Ind</label><br>
-           
-           <%= variables_form.radio_button :role, 'dependent' %>
-           <label for="role_dependent">Dep</label><br>
-           
-           <%= variables_form.radio_button :role, 'group_by' %>
-           <label for="role_group_by">Group By</label><br>
-         </li>
-        <% end %>
-       </ul>
+       <div class="viz-form-section">
+          <h4>Step 3 - Fill Chart Details (titles, variables etc.)</h4>
+
+          <div class="viz-form-group">
+            <label for="chart_title">Chart Title</label>
+            <%= f.text_field :chart_title %>
+          </div>
+
+          <div class="viz-form-group">
+            <label for="x_axis_title">X Axis Title</label>
+            <%= f.text_field :x_axis_title %>
+          </div>
+
+          <div class="viz-form-group">
+            <label for="y_axis_title">Y Axis Title</label>
+            <%= f.text_field :y_axis_title %>
+          </div>
+          
+          <b>Chart Variables:</b>
+          <ul>
+            <%= f.fields_for :variables do |variables_form| %>
+
+            <li>
+             
+              <div class="viz-form-group">
+                <label for="name">Name</label>
+                <%= variables_form.select :name, options_for_select(get_form_variable_names) %>
+              </div>
+
+              <div class="viz-form-group">
+                <label for="role">Role</label>
+                <%= variables_form.select :role, options_for_select(get_form_variable_roles) %>
+              </div>
+
+            </li>
+            <% end %>
+          </ul>
+       </div>
+
+
        <%= f.submit "Create Visualization!", class: "btn btn-primary" %>
       <% end %>
    </div>

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -1,2 +1,1 @@
-<h1>Visualization#show</h1>
-<p>Find me in app/views/visualization/show.html.erb</p>
+<h1 class="page-title">Visualization #XYZ</h1>


### PR DESCRIPTION
This PR cleans up some pages as well as the visualization form, opting for drop-down selection as opposed to a list of radio buttons.

It has been tested (without the filter variables section) and it successfully adds a visualization to the database. @trastopchin and I worked on the filters model but that has not been merged yet. Once that is merged, the form should be fully functional.

Please let's try and get this merged before our meeting with our client!
Thanks!

Also, here is what the visualization form looks like now:
<img width="1763" alt="Screen Shot 2020-10-08 at 11 57 34 AM" src="https://user-images.githubusercontent.com/43508242/95490187-81d8a700-095d-11eb-8d13-6c13a1063362.png">
