### PR TITLE
Implement preview page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,34 +44,40 @@
      width: 100%;
      box-sizing: border-box;
      padding: 0.7em 1em;
+
+     ul {
+        display: flex;
+        margin: 0;
+        padding: 0;
+        justify-content: center;
+    }
+
+    .nav-item{
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        list-style-type: none;
+        margin: 0 2em;
+    }
+
+    a{
+        color: white;
+        text-decoration: none;
+        border-bottom: solid transparent 2px;
+        padding: 0.5em 1em;
+
+        &:hover{
+            text-decoration: underline;
+        }
+    }
+
+    img{
+        margin-right: 8px;
+    }
+
  }
 
- .navbar-container ul {
-     display: flex;
-     margin: 0;
-     padding: 0;
-     justify-content: center;
- }
-
- .navbar-container .nav-item{
-     display: flex;
-     flex-direction: row;
-     justify-content: space-between;
-     align-items: center;
-     list-style-type: none;
-     margin: 0 2em;
- }
-
- .navbar-container a{
-     color: white;
-     text-decoration: none;
-     border-bottom: solid transparent 2px;
-     padding: 0.5em 1em;
- }
-
- .navbar-container a:hover{
-    text-decoration: underline;
-}
 
 /* Footer Styles */
 .footer-container {

--- a/app/assets/stylesheets/visualizations.scss
+++ b/app/assets/stylesheets/visualizations.scss
@@ -9,3 +9,58 @@
 .viz-form-group{
     margin-bottom: 12px;
 }
+
+.viz-thumbnail-group{
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    width: 80vw;
+    align-self: center;
+    margin-top: 5vh;
+}
+
+.viz-thumbnail-wrapper{
+    position: relative;
+    width: 392px;
+    height: 392px;
+    margin-right: 32px;
+    margin-bottom: 32px;
+}
+
+.viz-thumbnail{
+    width: 376px;
+    height: 376px;
+    background-color: white;
+    box-shadow: 0px 4px 50px rgba(0, 0, 0, 0.1);
+    border-radius: 10px;
+    
+    position: relative;
+    color: black;
+    display: block;
+
+    &:hover{
+        width: 392px;
+        height: 392px;
+        transition: .2s;
+        margin-top: -8px;
+        margin-left: -8px;
+    }
+}
+
+.viz-thumbnail-info{
+    position: absolute;
+    background-color:white;
+    box-shadow: 0px 4px 50px rgba(0, 0, 0, 0.1);
+    width: 100%;
+    bottom: 0;
+    height: 100px;
+    padding: 8px 16px;
+    border-bottom-left-radius: 10px;
+    border-bottom-right-radius: 10px;
+
+
+
+    .viz-thumbnail-title{
+        font-weight: bold;
+    }
+}

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -1,6 +1,6 @@
 class VisualizationsController < ApplicationController
   def index
-    
+    @visualizations = Visualization.order(updated_at: :desc)
   end
 
   def show

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,7 +1,25 @@
 <nav class="navbar-container">
     <ul>
-        <li class="nav-item"> <%= image_tag  "navbar/bar-chart.svg" %> <%= link_to "Preview", visualizations_path  %></li>
-        <li class="nav-item"><%= image_tag  "navbar/plus-circle.svg" %> <%= link_to "Visualize", new_visualization_path %></li>
-        <li class="nav-item"><%= image_tag  "navbar/upload.svg" %> <%= link_to "Upload", uploads_path %></li>
+        <%= link_to visualizations_path do %>
+            <li class="nav-item"> 
+                <%= image_tag  "navbar/bar-chart.svg" %> 
+                <div class="nav-text">Review</div>
+            </li>
+        <%end%>
+
+        <%= link_to new_visualization_path do %>
+            <li class="nav-item"> 
+                <%= image_tag  "navbar/plus-circle.svg" %> 
+                <div class="nav-text">Visualize</div>
+            </li>
+        <%end%>
+
+         <%= link_to uploads_path do %>
+            <li class="nav-item"> 
+                <%= image_tag  "navbar/upload.svg" %> 
+                <div class="nav-text">Upload</div>
+            </li>
+        <%end%>
+
     </ul>
 </nav>

--- a/app/views/visualizations/_thumbnail.html.erb
+++ b/app/views/visualizations/_thumbnail.html.erb
@@ -1,0 +1,8 @@
+<div class="viz-thumbnail-wrapper">
+<%= link_to visualization_path(locals[:visualization]), class: "viz-thumbnail" do %>
+    <div class="viz-thumbnail-info">
+        <p class="viz-thumbnail-title"><%= locals[:visualization].chart_title%></p>
+        <p class="">Last edited @<%= locals[:visualization].updated_at%></p>
+    </div>
+<%end%>
+</div>

--- a/app/views/visualizations/index.html.erb
+++ b/app/views/visualizations/index.html.erb
@@ -1,2 +1,8 @@
-<h1 class="page-title">Preview</h1>
-<p>See all your visualizations here! Coming soon...</p>
+<h1 class="page-title">Review</h1>
+<p>See all your visualizations on this page! Visualizations are ordered by the time they were last edited.</p>
+
+<div class="viz-thumbnail-group">
+<%@visualizations.each do |visualization|%>
+    <%= render "thumbnail", locals: {visualization: visualization}%>
+<%end%>
+</div>


### PR DESCRIPTION
This PR implements the Review (formerly Preview page). 

It renders thumbnails for visualizations that have been stored in the database in order of when they were last updated. When a user clicks on, a given thumbnail, they are redirected to the `show` page for the selected visualization.

Changes made:
1. Adding a new `_thumbnail.html.erb` partial to `visualizations` folder in `views`
1. Changing navbar and `visualizations/index.html.erb` page to say "Review" instead of "Preview"
1. Bunch of styles to make the thumbnails look legit!

NB: the messaging on the Review page is subject to change. I put a description that came to mind at the moment of implementation.

Here is what it looks like:
<img width="1751" alt="Screen Shot 2020-10-18 at 3 23 54 AM" src="https://user-images.githubusercontent.com/43508242/96362251-9f420980-10f1-11eb-8763-5f695024cccc.png">

