### PR TITLE
Refresh visualize page

### DIFF
--- a/app/assets/stylesheets/visualizations.scss
+++ b/app/assets/stylesheets/visualizations.scss
@@ -2,10 +2,80 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+.viz-page{
+   // box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.1);
+   width: 100%;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    flex-direction: row;
+}
+
+.viz-step{
+    font-weight: 600;
+    font-size: 1.2em;
+    margin-bottom: 1.5em;
+    margin-top: 4px;
+    text-decoration: underline;
+}
+
 .viz-form-section {
-    margin-bottom: 50px;
+    padding: 8px 0px;
+    margin-bottom: 8px;
+
+
+    label{
+       font-weight: 600; 
+       color: rgba(0, 0, 0, 0.8)
+    }
+
+    ul{
+        margin:0;
+        padding: 0;
+    }
+
+    select{
+        border-color: #ccc;
+        border-radius: 4px;
+        height: 32px;
+        padding: 4px 4px;
+        box-sizing: border-box;
+    }
 }
 
 .viz-form-group{
-    margin-bottom: 12px;
+    margin-right: 8px;
+    width: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.form-row{
+    list-style-type: none;
+    display: flex;
+    flex-direction: row;    
+    border: solid 1px #ccc;
+    border-radius: 4px;
+    margin-bottom: 16px;
+    padding: 24px 24px;
+    box-sizing: border-box;
+}
+
+.chart-details{
+    margin-bottom: 16px;
+
+    .viz-form-group{
+        margin-bottom: 16px;
+    }
+}
+
+.chart-details.form-row{
+    flex-direction: column;
+}
+
+.chart-variables{
+    b{
+        margin-bottom: 8px;
+        display: block;
+    }
 }

--- a/app/helpers/visualizations_helper.rb
+++ b/app/helpers/visualizations_helper.rb
@@ -1,7 +1,11 @@
 module VisualizationsHelper
+    def empty_option
+        [["--", ""]]
+    end
+
     def get_form_variable_names
+        empty_option +
         [
-            ["---", ""],
             ["class_year", "class_year"],
             ["major1", "major1"],
             ["major2", "major2"],
@@ -19,6 +23,7 @@ module VisualizationsHelper
 
     def get_form_chart_types
         # Each element has format [<Display Name>, <Value>]
+        empty_option +
         [
             ["Bar", "bar_chart"],
             ["Pie", "pie_chart"],
@@ -29,8 +34,8 @@ module VisualizationsHelper
 
     def get_form_variable_roles
         # Each element has format [<Display Name>, <Value>]
+        empty_option +
         [
-            ["---", ""],
             ["Group By", "group"],
             ["Independent", "independent"],
             ["Dependent", "dependent"]
@@ -39,8 +44,8 @@ module VisualizationsHelper
 
 
     def get_form_filter_types
+        empty_option +
         [
-            ["---", ""],
             ["From..To", "from_to"],
             ["Equals", "equals"],
             ["Is Greater Than", "greater_than"],
@@ -49,6 +54,23 @@ module VisualizationsHelper
             ["Is Less Than Or Equal To", "less_than_or_equal"]
 
         ]
+    end
+
+    def get_form_filter_values
+        options = empty_option
+
+        Student.column_names
+            .reject{|c| ["id", "student_id", "updated_at", "created_at"].include? c}
+            .each do |name|  
+                possible_values = Student.distinct.pluck(name)
+                puts "Possible values #{possible_values}"
+                possible_values.each do |value| 
+                    options = options + [["#{name}:#{value}", "#{value}"]]
+                end
+            end
+
+        puts "All options #{options}"
+        return options
     end
 
 end

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -1,8 +1,8 @@
 class Filter < ApplicationRecord
   belongs_to :visualization
-  validates :variable_name, presence: true
-  validates :filter_type, presence: true
-  validates :value1, presence: true
+  #validates :variable_name, presence: true
+  #validates :filter_type, presence: true
+  #validates :value1, presence: true
   # validates :value2, presence: true, unless: -> { value1.blank? }
   # TODO above
   

--- a/app/views/visualizations/new.html.erb
+++ b/app/views/visualizations/new.html.erb
@@ -1,33 +1,33 @@
 <h1 class="page-title">Visualize</h1>
 
-<div class="row">
-   <div class="col-md-20 col-md-offset-1">
+<div class="viz-page">
+   <div class="col-md-10 col-md-offset-1">
      <%= form_with(model: @visualization, local: true) do |f| %>
      <%= render 'shared/error_messages' %>
 
      <div class="viz-form-section">
-        <h4>Step 1 - Filter Data</h4>
+        <h4 class="viz-step" class="viz-step">Step 1 - Apply Filter(s)</h4>
         <ul>
           <%= f.fields_for :filters do |filters_form| %>
-          <li>
+          <li class="form-row">
             <div class="viz-form-group">
               <label for="variable_name">Variable</label>
-              <%= filters_form.select :variable_name, options_for_select(get_form_variable_names), class: 'form-control' %>
+              <%= filters_form.select :variable_name, options_for_select(get_form_variable_names), prompt: "Select variable", class: 'form-control' %>
             </div>
 
             <div class="viz-form-group">
               <label for="filter_type">Filter Type</label>
-              <%= filters_form.select :filter_type, options_for_select(get_form_filter_types), class: 'form-control' %>
+              <%= filters_form.select :filter_type, options_for_select(get_form_filter_types), prompt: "Select filter", class: 'form-control' %>
             </div>
 
             <div class="viz-form-group">
               <label for="value1">Value1</label>
-              <%= filters_form.text_field :value1, class: 'form-control' %>
+              <%= filters_form.select :value1, options_for_select(get_form_filter_values), prompt: "Select value", class: 'form-control' %>
             </div>
             
             <div class="viz-form-group">
               <label for="value2">Value2</label>
-              <%= filters_form.text_field :value2, class: 'form-control' %>
+              <%= filters_form.select :value2, options_for_select(get_form_filter_values), prompt: "Select value", class: 'form-control' %>
             </div>
 
           </li>
@@ -36,49 +36,57 @@
        </div>
 
        <div class="viz-form-section">
-          <h4>Step 2 - Select Chart Type</h4>
-          <label for="chart_type">Chart Type</label> 
-          <%= f.select :chart_type, options_for_select(get_form_chart_types), class: 'form-control' %>
+          <h4 class="viz-step">Step 2 - Select Chart Type</h4> 
+          <div class="form-row">
+          <div class="viz-form-group">         
+            <label for="chart_type">Chart Type</label> 
+            <%= f.select :chart_type, options_for_select(get_form_chart_types), prompt: "Select chart", class: 'form-control' %>
+          </div>
+          </div>
        </div>
        
        
        <div class="viz-form-section">
-          <h4>Step 3 - Fill Chart Details (titles, variables etc.)</h4>
+          <h4 class="viz-step">Step 3 - Fill Chart Details (titles, variables etc.)</h4>
 
-          <div class="viz-form-group">
-            <label for="chart_title">Chart Title</label>
-            <%= f.text_field :chart_title, class: 'form-control' %>
+            <div class="chart-variables">
+            <b>Chart Variables</b>
+            <ul>
+              <%= f.fields_for :variables do |variables_form| %>
+
+              <li class="form-row">
+
+                <div class="viz-form-group">
+                  <label for="role">Role</label>
+                  <%= variables_form.select :role, options_for_select(get_form_variable_roles), prompt: "Select role", class: 'form-control' %>
+                </div>
+
+                <div class="viz-form-group">
+                  <label for="name">Variable</label>
+                  <%= variables_form.select :name, options_for_select(get_form_variable_names), prompt: "Select variable", class: 'form-control' %>
+                </div>
+
+              </li>
+              <% end %>
+            </ul>
+        </div>
+
+          <div class="chart-details form-row">
+            <div class="viz-form-group">
+              <label for="chart_title">Chart Title</label>
+              <%= f.text_field :chart_title, class: 'form-control' %>
+            </div>
+
+            <div class="viz-form-group">
+              <label for="x_axis_title">X Axis Title</label>
+              <%= f.text_field :x_axis_title, class: 'form-control' %>
+            </div>
+
+            <div class="viz-form-group">
+              <label for="y_axis_title">Y Axis Title</label>
+              <%= f.text_field :y_axis_title, class: 'form-control' %>
+            </div>
           </div>
-
-          <div class="viz-form-group">
-            <label for="x_axis_title">X Axis Title</label>
-            <%= f.text_field :x_axis_title, class: 'form-control' %>
-          </div>
-
-          <div class="viz-form-group">
-            <label for="y_axis_title">Y Axis Title</label>
-            <%= f.text_field :y_axis_title, class: 'form-control' %>
-          </div>
-          
-          <b>Chart Variables:</b>
-          <ul>
-            <%= f.fields_for :variables do |variables_form| %>
-
-            <li>
-             
-              <div class="viz-form-group">
-                <label for="name">Name</label>
-                <%= variables_form.select :name, options_for_select(get_form_variable_names), class: 'form-control' %>
-              </div>
-
-              <div class="viz-form-group">
-                <label for="role">Role</label>
-                <%= variables_form.select :role, options_for_select(get_form_variable_roles), class: 'form-control' %>
-              </div>
-
-            </li>
-            <% end %>
-          </ul>
        </div>
 
 

--- a/app/views/visualizations/new.html.erb
+++ b/app/views/visualizations/new.html.erb
@@ -6,7 +6,7 @@
      <%= render 'shared/error_messages' %>
 
      <div class="viz-form-section">
-        <h4 class="viz-step" class="viz-step">Step 1 - Apply Filter(s)</h4>
+        <h4 class="viz-step" class="viz-step">Step 1 - Add Filter(s)</h4>
         <ul>
           <%= f.fields_for :filters do |filters_form| %>
           <li class="form-row">


### PR DESCRIPTION
This PR modifies the look of the visualizations form page to make it match the UI/UX designs(version 2) more closely.

**Changes**:
1. Style changes to make UI cleaner
1. `Value 1` and `Value 2` fields for filters have been changed from text-fields to drop-downs. These drop-downs contain a master list of all possible values for each field in the database. They are formatted as such "major:ENG", "intern:TRUE" etc.

**Downsides:**
The values list is preeetty long but it's the best workaround for now. Ideally, we would only pull possible values for the selected `variable` but that would probably entail using javascript. 
This implementation should suffice for now and serve the purpose of reducing the likelihood of human error when filling the form.


**Here's a look at the form page now:**
![Screen Recording 2020-10-18 at 5 26 00 AM](https://user-images.githubusercontent.com/43508242/96364948-f6040f00-1102-11eb-87d0-6176ed33cae4.gif)
